### PR TITLE
Add Support internal role

### DIFF
--- a/src/Likvido.Identity/Roles/LikvidoRoles.cs
+++ b/src/Likvido.Identity/Roles/LikvidoRoles.cs
@@ -2,16 +2,17 @@ namespace Likvido.Identity.Roles
 {
     public static class LikvidoRoles
     {
-        public static string[] VisibleRoles = 
-        { 
+        public static string[] VisibleRoles =
+        {
             Internals.Manager,
             Internals.Product,
             Internals.Operations,
             Internals.Payout,
             Internals.Owner,
+            Internals.Support,
             Internals.LikvidoEmployee,
-            Creditors.Creditor, 
-            Creditors.CreditorEmployee 
+            Creditors.Creditor,
+            Creditors.CreditorEmployee
         };
 
         public static string[] All =
@@ -21,6 +22,7 @@ namespace Likvido.Identity.Roles
             Internals.Operations,
             Internals.Payout,
             Internals.Owner,
+            Internals.Support,
             Internals.LikvidoEmployee,
             Creditors.Creditor,
             Creditors.CreditorEmployee,
@@ -35,6 +37,7 @@ namespace Likvido.Identity.Roles
             Internals.Operations,
             Internals.Payout,
             Internals.Owner,
+            Internals.Support,
         };
 
         public static string[] CreditorRoles = { Creditors.CreditorEmployee, Creditors.Creditor };
@@ -48,6 +51,7 @@ namespace Likvido.Identity.Roles
             public const string Product = "product";
             public const string Payout = "payout";
             public const string Owner = "owner";
+            public const string Support = "support";
         }
 
         public static class Creditors

--- a/src/version.props
+++ b/src/version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.1.6</Version>
+    <Version>1.1.7</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Add a new `Support` internal role for CS/support team access to Advanced Invoice Editor endpoints.

Adds `Internals.Support` constant with value `"support"` and includes it in `LikvidoInternalRoles`, `All`, and `VisibleRoles` arrays. This allows the support team to manage invoice fees and lines without requiring the broader `Operations` role.

Bumps version from 1.1.6 to 1.1.7.

Closes #26515.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Support role functionality for internal team members.

* **Chores**
  * Release version 1.1.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->