### PR TITLE
Do not persist git credentials in nuget workflow

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -8,6 +8,11 @@ on:
       - src/version.props
       - .github/workflows/nuget.yml
 
+# The job only checks out the repository and pushes the package to nuget.org, which is authenticated
+# with NUGET_API_KEY rather than the job token, so read access to the contents is all it needs.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6


### PR DESCRIPTION
Addresses Aikido issue **356907605** (group 33562783, LOW / score 30): "GitHub Action actions/checkout persist Git credentials in workflow".

## What changed
`.github/workflows/nuget.yml`:
- `persist-credentials: false` on the `actions/checkout` step, so the `GITHUB_TOKEN` is no longer written into `.git/config`.
- Added an explicit `permissions: contents: read` block. The file had no `permissions:` block, and the org default workflow permission is **write**, so the job was running with a `contents: write` token.

Action version pins are untouched — Dependabot owns those.

## Why this is safe here
The workflow performs **no git write operation** after checkout. Publishing happens inside `likvido/action-nuget`, which authenticates to nuget.org with `secrets.NUGET_API_KEY` (`dotnet nuget push -k ...`) — not the job token. The token is therefore entirely unused by this workflow.

## Why it is worth fixing
`action-nuget` runs `dotnet build -c Release`, which restores from nuget.org and executes third-party MSBuild targets in the same workspace that held a `contents: write` token in `.git/config`. This removes that credential from the build workspace and drops the token to read-only.

Matches the implementation already merged in `Likvido.Web`, `Likvido.Robot` and `Likvido.Telemetry` (comment, permissions block and checkout `with:` block copied verbatim).
